### PR TITLE
Load Season Data Change

### DIFF
--- a/backend/app/load_season_data.py
+++ b/backend/app/load_season_data.py
@@ -1,0 +1,29 @@
+from datetime import datetime, timedelta
+from app.load_pitch_data import load_pitch_data
+
+# Load data for a season day by day
+def load_range(start_date: str, end_date: str):
+    current = datetime.fromisoformat(start_date)
+    end = datetime.fromisoformat(end_date)
+
+    while current <= end:
+        day = current.strftime("%Y-%m-%d")
+        print(f"Loading day: {day}")
+
+        try:
+            load_pitch_data(day, day)
+        except Exception as e:
+            print(f"Error on {day}: {e}")
+        current += timedelta(days=1)
+
+
+if __name__ == "__main__":
+    print("Starting full season load")
+
+    # 2023 Season
+    load_range("2023-03-30", "2023-10-01")
+
+    # 2024 Season
+    load_range("2024-03-28", "2024-09-29")
+
+    print("All seasons loaded successfully")


### PR DESCRIPTION
Updated how we load seasons data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a day-by-day season loader that calls `load_pitch_data` and runs 2023/2024 ranges with basic error handling.
> 
> - **Backend**:
>   - **Season loader**: New `backend/app/load_season_data.py` with `load_range(start_date, end_date)` iterating per day and invoking `load_pitch_data`.
>   - **Runnable entrypoint**: Executes 2023 (`2023-03-30` to `2023-10-01`) and 2024 (`2024-03-28` to `2024-09-29`) seasons.
>   - **Error handling**: Catches and logs exceptions per day.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e7d571d8c0037f446db63d2f1953af9b1049a943. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->